### PR TITLE
fix: trust vector (vtr) for govuk-one-login-simulator

### DIFF
--- a/govuk_onelogin_django/views.py
+++ b/govuk_onelogin_django/views.py
@@ -45,7 +45,7 @@ UserModel = get_user_model()
 def get_trust_vector(
     auth_level: AuthenticationLevel, identity_level: IdentityConfidenceLevel
 ) -> dict[str, str]:
-    return {"vtr": f"['{auth_level}.{identity_level}']"}
+    return {"vtr": f'["{auth_level}.{identity_level}"]'}
 
 
 REDIRECT_SESSION_FIELD_NAME = f"_oauth2_{REDIRECT_FIELD_NAME}"


### PR DESCRIPTION
# Description

This addresses an issue when attempting to integrate with [govuk-one-login-simulator.](https://github.com/govuk-one-login/simulator/) When trying to login it fails, with the following surfaced in the log of the simulator
```
"Error parsing vtr value: Unexpected token ''', \"['Cl.Cm.P2']\" is not valid JSON"
"Authorise request error: invalid_request: Request vtr not valid"
```
This does not seem to occur with the cloud-based integration environment of GOV.UK One Login - it may allow Python-style arrays.

## Contributors

N/A

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Locally in two, albeit limited, situations

- Against the govuk-one-login simulator: the error about the vtr field does not occur
- Against the integration environment of govuk-one-login: the login flow is started (as it was before this change)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
