### PR TITLE
fix: double client_assertion_type in request

### DIFF
--- a/govuk_onelogin_django/utils.py
+++ b/govuk_onelogin_django/utils.py
@@ -118,9 +118,6 @@ def get_token(request: HttpRequest, auth_code: str) -> dict:
         # If you’re requesting a refresh token, you must set this parameter to refresh_token.
         # Otherwise, you need to set the parameter to authorization_code.
         grant_type="authorization_code",
-        # https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#make-a-post-request-to-the-token-endpoint
-        # Required value when using private_key_jwt auth.
-        client_assertion_type="urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
     )
 
     validate_token(request, token)


### PR DESCRIPTION
# Description

This addresses an issue with govuk-one-login-simulator, where it seems that fetching a token passes `client_assertion_type` _twice_ in the query string params.

From the log in the simulator:
```
"Validating request query params"
"client_assertion_type":["urn:ietf:params:oauth:client-assertion-type:jwt-bearer","urn:ietf:params:oauth:client-assertion-type:jwt-bearer"]
"Client Auth Method is private_key_jwt but client_assertion_type is incorrect"
```
`client_assertion_type` is an _array_ of correct values, rather than just a single correct value.

Suspect that this comes from having `&client_assertion_type=...&client_assertion_type=...` in the query string when making the request: servers can convert repeated query string params to an array.

The error seems to come from this code https://github.com/govuk-one-login/simulator/blob/48964a1d866dc082bd294d4edb2d123a02a13b0b/src/components/token/client-authentication/validate-private-key-jwt.ts#L26-L33

```python
if (
  tokenRequestBody.client_assertion_type !==
  "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
) {
  logger.warn(
    { client_assertion_type: tokenRequestBody.client_assertion_type },
    "Client Auth Method is private_key_jwt but client_assertion_type is incorrect"
  );
```

Looking into authlib, the library that handles most of the auth flow, suspect the other instance of `client_assertion_type` comes from here: https://github.com/authlib/authlib/blob/5d2e603ec5f10bd2c4bf20e2495c076370d65b74/authlib/oauth2/rfc7523/auth.py#L65-L71
```python
body = add_params_to_qs(
    body or "",
    [
        ("client_assertion_type", ASSERTION_TYPE),
        ("client_assertion", client_assertion),
    ],
)
```

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Tested locally against govuk-one-login-simulator, and the initial stages of the govuk-one-login integration environment.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
