### PR TITLE
fix: use different key for session next url

### DIFF
--- a/govuk_onelogin_django/tests/test_views.py
+++ b/govuk_onelogin_django/tests/test_views.py
@@ -9,11 +9,11 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 from django.core.cache import cache
-from django.test import Client, override_settings
+from django.test import Client, override_settings, RequestFactory
 from django.urls import reverse
 
 from govuk_onelogin_django.utils import TOKEN_SESSION_KEY, OneLoginConfig
-from govuk_onelogin_django.views import REDIRECT_SESSION_FIELD_NAME
+from govuk_onelogin_django.views import REDIRECT_SESSION_FIELD_NAME, get_next_url
 
 FAKE_OPENID_CONFIG_URL = "https://oidc.onelogin.gov.uk/.well-known/openid-configuration"
 FAKE_AUTHORIZE_URL = "https://oidc.onelogin.gov.uk/authorize"
@@ -331,3 +331,14 @@ class TestOIDCBackChannelLogoutView:
                 },
             ]
         }
+
+
+def test_get_next_url_ignores_staff_sso_redirect_session_key(settings):
+    settings.ALLOWED_HOSTS = ["testserver"]
+    request = RequestFactory().get("/")
+    request.session = {
+        "_oauth2_next": "/staff-sso/redirect/url",
+        REDIRECT_SESSION_FIELD_NAME: "/redirect/url",
+    }
+
+    assert get_next_url(request) == "/redirect/url"

--- a/govuk_onelogin_django/views.py
+++ b/govuk_onelogin_django/views.py
@@ -48,7 +48,7 @@ def get_trust_vector(
     return {"vtr": f'["{auth_level}.{identity_level}"]'}
 
 
-REDIRECT_SESSION_FIELD_NAME = f"_oauth2_{REDIRECT_FIELD_NAME}"
+REDIRECT_SESSION_FIELD_NAME = f"_govuk_onelogin_django_{REDIRECT_FIELD_NAME}"
 
 
 def get_next_url(request):


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

# Description

We had a bug in Prompt Payments where One Login was redirecting to the url our staff-sso protected endpoints normally redirect to. This was because both packages use the same session key.

It might be worth a follow-up PR for this package and staff-sso to make it so that they explicitly pop that key from the session after it's used, but I just wanted to get the smallest immediate fix in here first.

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
