### PR TITLE
fix: ensure authenticate uses OL backend

### DIFF
--- a/govuk_onelogin_django/tests/test_views.py
+++ b/govuk_onelogin_django/tests/test_views.py
@@ -80,28 +80,28 @@ class TestAuthCallbackView:
         "govuk_onelogin_django.views",
         get_oauth_state=mock.DEFAULT,
         get_token=mock.DEFAULT,
-        authenticate=mock.DEFAULT,
+        OneLoginBackend=mock.DEFAULT,
         login=mock.DEFAULT,
         autospec=True,
     )
     def test_auth_callback_view(self, **mocks):
         auth_code = "fake-auth-code"
         state = "fake-state"
+        user = User.objects.create_user(username="fake-sub")
 
         mocks["get_oauth_state"].return_value = state
         mocks["get_token"].return_value = {"token": "fake"}
+        mocks["OneLoginBackend"].return_value.authenticate.return_value = user
 
         response = self.client.get(f"{self.url}?code={auth_code}&state={state}")
 
-        assert self.client.session[TOKEN_SESSION_KEY] == {"token": "fake"}
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.url == settings.LOGIN_REDIRECT_URL
+        assert response.status_code == 302
 
     @mock.patch.multiple(
         "govuk_onelogin_django.views",
         get_oauth_state=mock.DEFAULT,
         get_token=mock.DEFAULT,
-        authenticate=mock.DEFAULT,
+        OneLoginBackend=mock.DEFAULT,
         login=mock.DEFAULT,
         autospec=True,
     )
@@ -116,8 +116,10 @@ class TestAuthCallbackView:
 
         auth_code = "fake-auth-code"
         state = "fake-state"
+        user = User.objects.create_user(username="fake-sub")
         mocks["get_oauth_state"].return_value = state
         mocks["get_token"].return_value = {"token": "fake"}
+        mocks["OneLoginBackend"].return_value.authenticate.return_value = user
 
         response = self.client.get(f"{self.url}?code={auth_code}&state={state}")
 

--- a/govuk_onelogin_django/views.py
+++ b/govuk_onelogin_django/views.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.contrib.auth import (
     REDIRECT_FIELD_NAME,
     SESSION_KEY,
-    authenticate,
     get_user_model,
     login,
 )
@@ -24,6 +23,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import RedirectView, View
 
+from .backends import OneLoginBackend
 from .types import AuthenticationLevel, IdentityConfidenceLevel
 from .utils import (
     TOKEN_SESSION_KEY,
@@ -134,7 +134,7 @@ class AuthCallbackView(View):
         delete_oauth_nonce(self.request)
 
         # Get or create the user
-        user = authenticate(request)
+        user = OneLoginBackend().authenticate(request)
 
         # Get next_url from session before "login" (which is essentially caching the user in the
         # session), because login can clear the session if the session belongs to another user.
@@ -145,7 +145,9 @@ class AuthCallbackView(View):
         next_url = get_next_url(request) or getattr(settings, "LOGIN_REDIRECT_URL", "/")
 
         if user is not None:
-            login(request, user)
+            login(
+                request, user, backend="govuk_onelogin_django.backends.OneLoginBackend"
+            )
 
             # Re-save token to session _after_ "login" (because login can clear the session as above)
             self.request.session[TOKEN_SESSION_KEY] = dict(token)


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

# Description

Makes `authenticate` and `login` explicitly use OL backend, so that apps using multiple backends within the same site don't hit "multiple backends configured" error or accidentally use staff-sso backend, when OL is expected.

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
